### PR TITLE
fix(auth): correctly handle expired JWTs by removing duplicate exp fi…

### DIFF
--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -264,7 +264,7 @@ func (h *AuthHandler) UserInfo(c *gin.Context) {
 		"name":  userClaims.Name,
 		"iss":   userClaims.Iss,
 		"aud":   userClaims.Aud,
-		"exp":   userClaims.Exp,
+		// "exp":   userClaims.Exp,
 		"iat":   userClaims.Iat,
 	})
 }

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -19,13 +19,13 @@ import (
 
 // Claims defines the structure of the JWT claims.
 // It embeds jwt.RegisteredClaims to handle standard claims like expiration (exp),
-type Claims struct {
-	Email string `json:"email"`
-	Name  string `json:"name"`
-	Sub   string `json:"sub"`
-	Iss   string `json:"iss"`
-	jwt.RegisteredClaims
-}
+// type Claims struct {
+// 	Email string `json:"email"`
+// 	Name  string `json:"name"`
+// 	Sub   string `json:"sub"`
+// 	Iss   string `json:"iss"`
+// 	jwt.RegisteredClaims
+// }
 
 func CORSMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -42,7 +42,7 @@ func CORSMiddleware() gin.HandlerFunc {
 	}
 }
 
-func AuthMiddleware() gin.HandlerFunc {
+func 	AuthMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		authHeader := c.GetHeader("Authorization")
 		if authHeader == "" {
@@ -288,13 +288,13 @@ func (h *AuthHandler) Callback(c *gin.Context) {
 }
 
 // ValidateToken validates a token string.
-func (h *AuthHandler) ValidateToken(tokenString string) (*Claims, error) {
+func (h *AuthHandler) ValidateToken(tokenString string) (*models.Claims, error) {
 	secret := []byte(os.Getenv("JWT_SECRET"))
 	if len(secret) == 0 {
 		secret = []byte("secret-key")
 	}
 
-	claims := &Claims{}
+	claims := &models.Claims{}
 	token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/SebbieMzingKe/customer-order-api/internal/handlers"
 	"github.com/SebbieMzingKe/customer-order-api/internal/models"
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v4"
@@ -23,13 +22,13 @@ func generateTestToken(email string, secret []byte, expired bool) string {
 		expirationTime = time.Now().Add(-24 * time.Hour)
 	}
 
-	claims := &handlers.Claims{
+	claims := &models.Claims{
 		Email: email,
 		Sub:   email,
 		Name:  "test user",
 		Iss:   "customer-order-api",
 		Aud:   "customer-order-api",
-		Exp:   expirationTime.Unix(),
+		// Exp:   expirationTime.Unix(),
 		Iat:   time.Now().Unix(),
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(expirationTime),

--- a/internal/models/claims.go
+++ b/internal/models/claims.go
@@ -8,7 +8,7 @@ type Claims struct {
 	Name  string `json:"name"`
 	Iss   string `json:"iss"`
 	Aud   string `json:"aud"`
-	Exp   int64  `json:"exp"`
+	// Exp   int64  `json:"exp"`
 	Iat   int64  `json:"iat"`
 	jwt.RegisteredClaims
 }


### PR DESCRIPTION
…eld.
- remove custom `Exp int64` from Claims struct to rely on `RegisteredClaims.ExpiresAt`
- update test token generator to set expiration only via `jwt.RegisteredClaims`
- ensure expired tokens are properly rejected with 401 in middleware